### PR TITLE
async operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ out
 
 coverprofile.out
 .vendor-new
+.idea

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -266,6 +266,14 @@
   version = "v1.0.1"
 
 [[projects]]
+  digest = "1:5d231480e1c64a726869bc4142d270184c419749d34f167646baa21008eb0a79"
+  name = "github.com/mitchellh/go-homedir"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "af06845cf3004701891bf4fdb884bfe4920b3727"
+  version = "v1.1.0"
+
+[[projects]]
   branch = "master"
   digest = "1:5ab79470a1d0fb19b041a624415612f8236b3c06070161a910562f2b2d064355"
   name = "github.com/mitchellh/mapstructure"
@@ -901,6 +909,7 @@
   input-imports = [
     "github.com/gogo/protobuf/proto",
     "github.com/google/uuid",
+    "github.com/mitchellh/go-homedir",
     "github.com/prometheus/client_golang/prometheus",
     "github.com/sirupsen/logrus",
     "github.com/spf13/cobra",

--- a/bot/pitaya_client.go
+++ b/bot/pitaya_client.go
@@ -146,8 +146,14 @@ func (c *PClient) Notify(route string, data []byte) error {
 }
 
 // ReceivePush ...
-func (c *PClient) ReceivePush(route string, timeout int) (Response, error) {
+func (c *PClient) ReceivePush(
+	route string,
+	timeout int,
+	ready chan struct{},
+) (Response, error) {
 	ch := c.getPushChannelForRoute(route)
+
+	ready <- struct{}{}
 
 	select {
 	case data := <-ch:

--- a/docs/test_writing.md
+++ b/docs/test_writing.md
@@ -37,6 +37,7 @@ Operation is the generalistic struct which contains the action that the specifie
 
 * `Type`: Type of operation which the bot will do. Each bot has different types
 * `Timeout`: Time that the bot has to execute given operation
+* `DontWait`: If true fires the operation and goes to next one, defaults to false; valid only for type equals push and request
 * `Uri`: URI which the bot will use to make request, notification, listen, ...
 * `Args`: Arguments that will be used in given operation
 * `Expect`: Expected result from operation

--- a/kubernetes/manager.go
+++ b/kubernetes/manager.go
@@ -163,7 +163,7 @@ func newJobSpec(restartPolicy corev1.RestartPolicy, specName, configName, workfl
 					},
 				},
 				Command: []string{"./main"},
-				Args:    []string{"run", "--config", "/etc/pitaya-bot/config.yaml", "--duration", duration.String(), "-d", "/etc/pitaya-bot/specs", "-t", workflowType, fmt.Sprintf("--report-metrics=%t", shouldReportMetrics)},
+				Args:    []string{"run", "--logJSON", "--config", "/etc/pitaya-bot/config.yaml", "--duration", duration.String(), "-d", "/etc/pitaya-bot/specs", "-t", workflowType, fmt.Sprintf("--report-metrics=%t", shouldReportMetrics)},
 			},
 		},
 		Volumes: []corev1.Volume{

--- a/models/spec.go
+++ b/models/spec.go
@@ -48,11 +48,12 @@ type ExpectSpec map[string]ExpectSpecEntry
 
 // Operation defines an operation the bot may execute
 type Operation struct {
-	Type    string                 `json:"type"`
-	Timeout int                    `json:"timeout,omitempty"`
-	URI     string                 `json:"uri"`
-	Args    map[string]interface{} `json:"args"`
-	Expect  ExpectSpec             `json:"expect,omitempty"`
-	Store   StoreSpec              `json:"store,omitempty"`
-	Change  map[string]interface{} `json:"change,omitempty"`
+	Type     string                 `json:"type"`
+	Timeout  int                    `json:"timeout,omitempty"`
+	DontWait bool                   `json:"dontWait,omitempty"`
+	URI      string                 `json:"uri"`
+	Args     map[string]interface{} `json:"args"`
+	Expect   ExpectSpec             `json:"expect,omitempty"`
+	Store    StoreSpec              `json:"store,omitempty"`
+	Change   map[string]interface{} `json:"change,omitempty"`
 }


### PR DESCRIPTION
New flag `dontWait` on push and request that fires the operation and continues. Defaults to false.

Usecases:
1. During the route execution, a push is called on server; in this case, you want to set a push operation with `dontWait: true`  before the request operation so during the request execution the push is received
2. A push is sent after a request execution due to an external service call, but you want to wait for this push to be received on bot, and there is a race condition that the push can be sent even before the request is finished