### PR TITLE
Added Sleep function to bots

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -8,4 +8,5 @@ type Bot interface {
 	Connect(...string) error
 	Disconnect()
 	Reconnect()
+	Sleep(int)
 }

--- a/bot/sequential.go
+++ b/bot/sequential.go
@@ -3,6 +3,7 @@ package bot
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -164,6 +165,8 @@ func (b *SequentialBot) runFunction(op *models.Operation) error {
 		b.Connect(host)
 	case "reconnect":
 		b.Reconnect()
+	case "sleep":
+		b.Sleep(op.Timeout)
 	default:
 		return fmt.Errorf("Unknown function: %s", fName)
 	}
@@ -282,3 +285,10 @@ func (b *SequentialBot) Reconnect() {
 	b.Connect()
 	b.logger.Debug("Reconnect done")
 }
+
+//Sleep
+func (b *SequentialBot) Sleep(timeout int) {
+	time.Sleep(time.Duration(timeout) * time.Millisecond)
+	b.logger.Debug("Sleeping")
+}
+


### PR DESCRIPTION
With the add of the new "Sleep" function, the bot can wait some specific time before going to the next message in the sequentialOperations, for that, we've added a new function "sleep" to the pitaya-bot (Currently, there is the "connect", "disconnect" and "reconnect" functions).
The usage is pretty simple, just put a sleep function call like between sequentialOperations, and the bot will wait the time specified (5000ms in the example below) in the "timeout" property.

```
{
  "type": "function",
  "uri": "sleep",
   "timeout": 5000
}
```